### PR TITLE
Overload newSSlContext to accept an InputStream

### DIFF
--- a/android/src/main/java/com/onehilltech/selfsigned/android/AndroidSelfSigned.java
+++ b/android/src/main/java/com/onehilltech/selfsigned/android/AndroidSelfSigned.java
@@ -31,13 +31,13 @@ public class AndroidSelfSigned
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException
   {
     InputStream caInput = new BufferedInputStream (context.getAssets ().open (assetFile));
-    return newSSLContext(type, caInput);
+    return newSSLContext (type, caInput);
   }
 
   public static SSLContext newSSLContext (InputStream caInput)
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException
   {
-    return newSSLContext(DEFAULT_CA_TYPE, caInput);
+    return newSSLContext (DEFAULT_CA_TYPE, caInput);
   }
 
   public static SSLContext newSSLContext (String type, InputStream caInput)

--- a/android/src/main/java/com/onehilltech/selfsigned/android/AndroidSelfSigned.java
+++ b/android/src/main/java/com/onehilltech/selfsigned/android/AndroidSelfSigned.java
@@ -30,9 +30,20 @@ public class AndroidSelfSigned
   public static SSLContext newSSLContext (Context context, String type, String assetFile)
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException
   {
-    CertificateFactory cf = CertificateFactory.getInstance (type);
     InputStream caInput = new BufferedInputStream (context.getAssets ().open (assetFile));
+    return newSSLContext(type, caInput);
+  }
 
+  public static SSLContext newSSLContext (InputStream caInput)
+      throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException
+  {
+    return newSSLContext(DEFAULT_CA_TYPE, caInput);
+  }
+
+  public static SSLContext newSSLContext (String type, InputStream caInput)
+      throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException
+  {
+    CertificateFactory cf = CertificateFactory.getInstance (type);
     try
     {
       Certificate ca = cf.generateCertificate (caInput);


### PR DESCRIPTION
Since you load the asset file as an InputStream to read the ca from it, I added the possibility to do it straight from an InputStream.  
I needed this for a project where we don't know what the ca certificates will be in advance, but we don't want to accept all CAs to prevent men in the middle attacks. We have a database that contains different servers, and we'll have the CAs for each server in the database. So it's simple for us to just store a string in the database and create an `InputStream` from it to pass to `newSSlContext`.